### PR TITLE
Add a patch to fix intel builds of b2 in boost

### DIFF
--- a/var/spack/repos/builtin/packages/boost/build-intel-static-1.78.0.patch
+++ b/var/spack/repos/builtin/packages/boost/build-intel-static-1.78.0.patch
@@ -1,0 +1,14 @@
+diff -ruN build/src/engine/build.sh build-patch/src/engine/build.sh
+--- build/src/engine/build.sh	2022-03-04 11:09:07.907995739 +0100
++++ build-patch/src/engine/build.sh	2022-03-04 11:10:19.450714230 +0100
+@@ -329,8 +329,8 @@
+ 
+     intel-*)
+         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+-        B2_CXXFLAGS_RELEASE="-O3 -s -static"
+-        B2_CXXFLAGS_DEBUG="-O0 -g -p -static"
++        B2_CXXFLAGS_RELEASE="-O3 -static-intel"
++        B2_CXXFLAGS_DEBUG="-O0 -g -p -static-intel"
+     ;;
+ 
+     vacpp)

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -310,6 +310,11 @@ class Boost(Package):
           when="@1.77.0",
           working_dir="tools/build")
 
+    # Fix static linking of b2 with Intel compilers
+    patch("build-intel-static-1.78.0.patch",
+          when="@1.78.0",
+          working_dir="tools/build")
+
     # Fix issues with PTHREAD_STACK_MIN not being a DEFINED constant in newer glibc
     # See https://github.com/spack/spack/issues/28273
     patch("pthread-stack-min-fix.patch", when="@1.69.0:1.72.0")


### PR DESCRIPTION
This patch seems to be needed for `boost` to build on Anvil and Chrysalis (maybe elsewhere).