### PR TITLE
Fix enabling of mpas interface in Albany package

### DIFF
--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -80,7 +80,7 @@ class Albany(CMakePackage):
                        '-DENABLE_FAD_TYPE:STRING=%s' % (
                            'SFad' if '+sfad' in spec else 'DFad'),
                        '-DENABLE_MPAS_INTERFACE:BOOL=%s' % (
-                           'ON' if 'mpas' in spec else 'OFF')
+                           'ON' if '+mpas' in spec else 'OFF')
                        ])
 
         if '+sfad' in spec: 

--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -79,7 +79,7 @@ class Albany(CMakePackage):
                            'ON' if '+64bit' in spec else 'OFF'),
                        '-DENABLE_FAD_TYPE:STRING=%s' % (
                            'SFad' if '+sfad' in spec else 'DFad'),
-                       '-DENABLE_MPAS_INTERFACE:=%s' % (
+                       '-DENABLE_MPAS_INTERFACE:BOOL=%s' % (
                            'ON' if 'mpas' in spec else 'OFF')
                        ])
 


### PR DESCRIPTION
In the Albany package, the MPAS interface wasn't getting built properly, possibly because of a missing `BOOL` in the CMake flag.