### PR TITLE
Fix PyAlbany compilation

### DIFF
--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -80,7 +80,7 @@ class Albany(CMakePackage):
     depends_on("trilinos-for-albany@develop", when="@develop")
     depends_on("trilinos-for-albany@compass-2023-08-03", when="@compass-2023-08-03")
 
-    extends("python",             when="+py")
+    extends("python@:3.9",        when="+py")
 
     depends_on("py-pybind11",     when="+py")
     depends_on("py-numpy",        when="+py")
@@ -125,6 +125,8 @@ class Albany(CMakePackage):
                            "ON" if "+mpas" in spec else "OFF"),
                        "-DENABLE_ALBANY_PYTHON:BOOL=%s" % (
                            "ON" if "+py" in spec else "OFF"),
+                       "-DPYTHON_EXECUTABLE=%s" % (
+                           spec["python"].command.path if "+py" in spec else ""),
                        "-DENABLE_ALBANY_EPETRA:BOOL=%s" % (
                            "ON" if "+epetra" in spec else "OFF"),
                        "-DENABLE_MESH_DEPENDS_ON_PARAMETERS:BOOL=%s" % (


### PR DESCRIPTION
This PR fixes #25 by constraining the python version to not be greater than 3.9.
It seems that the PyBind11 version used when compiling PyAlbany through spack is not new enough to support python 3.11 (which was the Python version used by default in my case).

PyAlbany does not require Python 3.11 or any version of python newer than 3.9. So, instead of fixing the logic at the PyBind11 spackage, I preferred to constrain the version at the Albany level as this only modify recipes that we own.

Note that the addition of `-DPYTHON_EXECUTABLE` is not required to fix the issue but this is cleaner when people run spack with `--dirty` as this line forces the usage of the spack-installed version of python and not the one from the system used to run spack for instance.