### PR TITLE
Add cuda-related variants for Albany and Trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -41,6 +41,10 @@ class Albany(CMakePackage):
             description="Enable SFad build")
     variant("sandybridge", default=False,
             description="Compile Trilinos used by Albany for Sandybridge architecture")
+    variant("zen3", default=False,
+            description="Compile Trilinos used by Albany for Zen3 architecture")
+    variant("ampere80", default=False,
+            description="Compile Trilinos used by Albany for Ampere80 architecture")
     variant("mpas",          default=False,
             description="Enable MPAS interface in build")
     variant("sfadsize", default="4", values=("4", "6", "8", "12", "24"), multi=False,
@@ -53,6 +57,10 @@ class Albany(CMakePackage):
             description="Enable packages needed for Albany optimization capabilities (SuperLU, FROSCh, ROL)"),
     variant("omegah",          default=False,
             description="Enable Omega_h in build")
+    variant("cuda", default=False,
+            description="Enable CUDA in build")
+    variant("uvm", default=False, when="+cuda",
+            description="Enable UVM for CUDA builds")
 
     # Add dependencies
     depends_on("mpi")
@@ -67,6 +75,11 @@ class Albany(CMakePackage):
 
     depends_on("trilinos-for-albany~superlu-dist+exodus+chaco~isorropia+tempus+teko~intrepid+intrepid2+minitensor+phalanx+pnetcdf+nox+piro+shards+stk+amesos2~amesos~hypre+ifpack2~mumps~suite-sparse~epetra~ifpack~ml+muelu~aztec+superlu+rol+frosch gotype=long_long", when="~sandybridge+optimization")
     depends_on("trilinos-for-albany~superlu-dist+exodus+chaco~isorropia+tempus+teko~intrepid+intrepid2+minitensor+phalanx+pnetcdf+nox+piro+shards+stk+amesos2~amesos~hypre+ifpack2~mumps~suite-sparse+sandybridge~epetra~ifpack~ml+muelu~aztec+superlu+rol+frosch gotype=long_long", when="+sandybridge+optimization")
+
+    depends_on("trilinos-for-albany+cuda+uvm", when="+uvm")
+    depends_on("trilinos-for-albany+cuda", when="+cuda~uvm")
+    depends_on("trilinos-for-albany+zen3", when="+zen3")
+    depends_on("trilinos-for-albany+ampere80", when="+ampere80")
 
     depends_on("trilinos-for-albany@develop", when="@develop")
     depends_on("trilinos-for-albany@compass-2023-08-03", when="@compass-2023-08-03")

--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -61,6 +61,8 @@ class Albany(CMakePackage):
             description="Enable CUDA in build")
     variant("uvm", default=False, when="+cuda",
             description="Enable UVM for CUDA builds")
+    variant("slfad", default=False,
+            description="Enable SLFad build")
 
     # Add dependencies
     depends_on("mpi")
@@ -124,8 +126,6 @@ class Albany(CMakePackage):
                            "ON" if "+perf" in spec else "OFF"),
                        "-DENABLE_64BIT_INT:BOOL=%s" % (
                            "ON" if "+64bit" in spec else "OFF"),
-                       "-DENABLE_FAD_TYPE:STRING=%s" % (
-                           "SFad" if "+sfad" in spec else "DFad"),
                        "-DENABLE_MPAS_INTERFACE:BOOL=%s" % (
                            "ON" if "+mpas" in spec else "OFF"),
                        "-DENABLE_ALBANY_PYTHON:BOOL=%s" % (
@@ -142,8 +142,22 @@ class Albany(CMakePackage):
 
         if "+sfad" in spec:
           options.extend([
+            "-DENABLE_FAD_TYPE:STRING=SFad",
             "-DALBANY_SFAD_SIZE=%d" % int(spec.variants["sfadsize"].value)
                        ])
+        elif "+slfad" in spec:
+          options.extend([
+            "-DENABLE_FAD_TYPE:STRING=SLFad",
+            "-DENABLE_TAN_FAD_TYPE:STRING=SLFad",
+            "-DENABLE_HES_VEC_FAD_TYPE:STRING=SLFad",
+            "-DALBANY_SLFAD_SIZE=90",
+            "-DALBANY_TAN_SLFAD_SIZE=100",
+            "-DALBANY_HES_VEC_SLFAD_SIZE=100"
+                       ])
+        else:
+          options.extend([
+            "-DENABLE_FAD_TYPE:STRING=DFad"])
+
         if "+debug" in spec:
           options.extend([
             "-DCMAKE_BUILD_TYPE:STRING=DEBUG"

--- a/var/spack/repos/builtin/packages/trilinos-for-albany/package.py
+++ b/var/spack/repos/builtin/packages/trilinos-for-albany/package.py
@@ -814,11 +814,12 @@ class TrilinosForAlbany(CMakePackage):
                 '-DKokkos_ENABLE_CUDA_UVM:BOOL=%s' % 'ON' if '+uvm' in spec else 'OFF',
                 '-DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC:BOOL=OFF',
                 '-DTPL_ENABLE_CUDA:BOOL=ON',
-                '-DTPL_ENABLE_CUSPARSE:BOOL=OFF'
+                '-DTPL_ENABLE_CUSPARSE:BOOL=OFF',
+                '-DTPL_ENABLE_THRUST:BOOL=ON'
             ])
             if '+tpetra' in spec:
                 options.extend([
-                    '-DTpetra_ASSUME_CUDA_AWARE_MPI:BOOL=%s' % 'ON' if '+aware' in spec else 'OFF'
+                    '-DTpetra_ASSUME_GPU_AWARE_MPI:BOOL=%s' % 'ON' if '+aware' in spec else 'OFF'
                 ])
 
         # Fortran lib


### PR DESCRIPTION
This PR adds variants to albany and trilinos-for-albany spack recipes to support CUDA builds.

A few notes about the included variants:
1) DFad Sacado types do not work on GPU so I've added an SLFad variant to Albany as an alternative that will work for all GPU cases.
2) CUDA Unified Virtual Memory (UVM) is off by default but can be enabled by adding +uvm
3) Same for Tpetra's GPU_AWARE_MPI (add +aware to enable)
4) Added +zen3 and +ampere80 architecture flags for Perlmutter-GPU