### PR TITLE
Update e3sm-scorpio

### DIFF
--- a/var/spack/repos/builtin/packages/e3sm-scorpio/package.py
+++ b/var/spack/repos/builtin/packages/e3sm-scorpio/package.py
@@ -25,11 +25,6 @@ class E3smScorpio(CMakePackage):
     version("1.6.0", sha256="fcc18b7eaf0dae4fc83e17a7ca2fc695f476fa96539881e37406efbcb821947d")
     version("1.4.2", sha256="e41b2725b2389df48b91932224a0dfb8c8fe6e98c7a49e1dfd65f7d49f7ffa81")
     version("1.4.1", sha256="7cb4589410080d7e547ef17ddabe68f749e6af019c1d0e6ee9f11554f3ff6b1a")
-    version("1.3.2", sha256="663805fa24e85c88509ecd7893264e3d7d2ff27efb304e0f75dd1f0c450b08a6")
-    version("1.3.1", sha256="4ee6db92fff562e49c58ca1e147f242dd6c7168b7d10c3ec47b399f0d683ce5b")
-    version("1.2.2", sha256="f944a8b8527b188cf474d9cd26c0aaae5d8a263c245eb67cad92d8dd02ca7bfb")
-    version("1.2.1", sha256="b106843008dd33fed8e2aca0cb5f13733342e398d94a489a0d474dfac8c902cc")
-    version("1.2.0", sha256="db2b8db71fe65c5152c10df255ab45a7f5a8870219fc2034ca29feba02c8167b")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated

--- a/var/spack/repos/builtin/packages/e3sm-scorpio/package.py
+++ b/var/spack/repos/builtin/packages/e3sm-scorpio/package.py
@@ -30,39 +30,48 @@ class E3smScorpio(CMakePackage):
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
 
-    variant("timing", default=False, description="Enable timing")
+    variant("timing", default=False, description="Enable GPTL timing")
     variant("mpi", default=True, description="Enable MPI")
+    variant("internal-timing", default=False,
+            description="Gather and print GPL timing stats")
+    variant("tools", default=False, description="Enable SCORPIO tools")
+    variant("malloc", default=True,
+            description="Use native malloc (instead of bget package)")
 
     depends_on("gptl", when="+timing")
     depends_on("mpi", when="+mpi")
-    depends_on("parallel-netcdf", when="+mpi")
-    depends_on("netcdf-c")
-    depends_on("netcdf-fortran")
+    depends_on("parallel-netcdf", type="link", when="+mpi")
+    depends_on("netcdf-c", type="link")
+    depends_on("netcdf-fortran", type="link")
 
     def cmake_args(self):
-        opts = []
-        opts.append(self.define("NetCDF_C_PATH", self.spec["netcdf-c"].prefix))
-        opts.append(self.define("NetCDF_Fortran_PATH", self.spec["netcdf-fortran"].prefix))
+        define = self.define
+        define_from_variant = self.define_from_variant
+        spec = self.spec
+        args = [
+            define("NetCDF_C_PATH", spec["netcdf-c"].prefix),
+            define("NetCDF_Fortran_PATH", spec["netcdf-fortran"].prefix),
+        ]
 
         if self.spec.satisfies("+timing"):
-            opts.append(self.define("PIO_ENABLE_TIMING", "ON"))
-            opts.append(self.define("GPTL_PATH", self.spec["gptl"].prefix))
-        else:
-            opts.append(self.define("PIO_ENABLE_TIMING", "OFF"))
+            args.append(define("GPTL_PATH", spec["gptl"].prefix))
 
-        if self.spec.satisfies("+mpi"):
-            opts.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))
-            opts.append(self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx))
-            opts.append(self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc))
-            opts.append(self.define("WITH_PNETCDF", "ON"))
-            opts.append(self.define("PNETCDF_PATH", self.spec["parallel-netcdf"].prefix))
-        else:
-            opts.append(self.define("WITH_PNETCDF", "OFF"))
+        if spec.satisfies("+mpi"):
+            args.append(define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
+            args.append(define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
+            args.append(define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
+            args.extend([
+                define("PnetCDF_C_PATH", spec["parallel-netcdf"].prefix),
+                define("PnetCDF_Fortran_PATH", spec["parallel-netcdf"].prefix),
+            ])
 
-        return opts
+        args.extend([
+            define_from_variant("WITH_PNETCDF", "mpi"),
+            define_from_variant("PIO_ENABLE_TIMING", "timing"),
+            define_from_variant("PIO_ENABLE_INTERNAL_TIMING",
+                                "internal-timing"),
+            define_from_variant("PIO_ENABLE_TOOLS", "tools"),
+            define_from_variant("PIO_USE_MALLOC", "malloc"),
+        ])
 
-    def setup_build_environment(self, env):
-        env.set("NetCDF_C_PATH", self.spec["netcdf-c"].prefix)
-        env.set("NetCDF_Fortran_PATH", self.spec["netcdf-fortran"].prefix)
-        if self.spec.satisfies("+mpi"):
-            env.set("PNETCDF_PATH", self.spec["parallel-netcdf"].prefix)
+        return args


### PR DESCRIPTION
This merge removes older e3sm-scorpio versions so we don't have to patch them

It also adds 3 variants to e3sm-scorpio---`internal-timing`, `tools` and `malloc`---from our version of the `scorpio` package on the E3SM-Project fork.